### PR TITLE
[vds3] Flesh out versioning support, ditch subprocess for testing

### DIFF
--- a/plugins/vds3.py
+++ b/plugins/vds3.py
@@ -218,12 +218,11 @@ def openurl_s3(p, filetype, version_aware=None, version_id=None):
     # string as the default instead, and convert back to None here.
     endpoint = vd.options.vds3_endpoint or None
 
-    if not isinstance(p, S3Path):
-        p = S3Path(
-            str(p.given),
-            version_aware=version_aware or vd.options.vds3_version_aware,
-            version_id=version_id,
-        )
+    p = S3Path(
+        str(p.given),
+        version_aware=version_aware or vd.options.vds3_version_aware,
+        version_id=version_id,
+    )
 
     p.fs.version_aware = p.version_aware
     if p.fs.client_kwargs.get('endpoint_url', '') != endpoint:

--- a/plugins/vds3.py
+++ b/plugins/vds3.py
@@ -136,7 +136,6 @@ class S3DirSheet(Sheet):
         list_func = self.fs.glob if self.use_glob_matching else self.fs.ls
 
         for key in list_func(str(self.source)):
-            vd.status(f'loading: {key}')
             if self.version_aware and self.fs.isfile(key):
                 yield from (
                     {**version_info, 'Key': key, 'type': 'file'}
@@ -182,18 +181,12 @@ class S3DirSheet(Sheet):
 
         super().reload()
 
-    def refresh(self):
+    def refresh(self, path=None):
         '''
-        Clear the s3fs cache for this path and its children, then reload.
+        Clear the s3fs cache for the given path and reload. By default, clear
+        the entire cache.
         '''
-        self.fs.invalidate_cache(str(self.source))
-        self.reload()
-
-    def refresh_all(self):
-        '''
-        Clear the entire s3fs cache, then reload.
-        '''
-        self.fs.invalidate_cache()
+        self.fs.invalidate_cache(path)
         self.reload()
 
     def toggle_versioning(self):
@@ -263,7 +256,7 @@ S3DirSheet.addCommand(
 S3DirSheet.addCommand(
     'z^R',
     'refresh-sheet',
-    'sheet.refresh()',
+    'sheet.refresh(str(sheet.source))',
     'clear the s3fs cache for this path, then reload',
 )
 S3DirSheet.addCommand(

--- a/tests/home/.visidatarc
+++ b/tests/home/.visidatarc
@@ -1,3 +1,4 @@
 import plugins.vds3
+from visidata import vd
 
-options.vds3_endpoint = 'http://localhost:3000'
+vd.options.vds3_endpoint = 'http://localhost:3000'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-env
-git+https://github.com/saulpw/visidata@v2.-3.0
+git+https://github.com/saulpw/visidata@v2.-4.0
 boto3
 s3fs
 moto[server]


### PR DESCRIPTION
This change ended up being more significant than I planned. There are still some things I want to revisit, but this seems like a good checkpoint.

**Plugin changes**

* Proper support for S3 versioning, with a command to quick-toggle version support (`^V` by default).
* Don't force a refresh from S3 when reloading a sheet. Explicitly invalidate caches on demand:
  * `z^R`: clear cache for the current S3 path and its children
  * `gz^R`: clear the whole s3fs cache
* Refactor some code to better fit with VisiData 2.0 plugin author guidelines.

**Test changes**

* Replace `moto_server` subprocess with `multiprocessing.Process`.
* Replace `vd` subprocess with a helper method that calls VisiData methods directly.